### PR TITLE
fix(monitoring): scrape Talos etcd metrics on :2381

### DIFF
--- a/kubernetes/apps/monitoring/victoriametrics/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoriametrics/app/helmrelease.yaml
@@ -226,6 +226,19 @@ spec:
       enabled: true
     kubeEtcd:
       enabled: true
+      endpoints:
+        - 10.40.0.101
+        - 10.40.0.102
+        - 10.40.0.103
+      service:
+        enabled: true
+        port: 2381
+        targetPort: 2381
+      vmScrape:
+        spec:
+          endpoints:
+            - port: http-metrics
+              scheme: http
     kubeScheduler:
       enabled: true
       endpoints: []


### PR DESCRIPTION
kubeEtcd ran on chart defaults (:2379 HTTPS+certs, empty endpoints), but Talos exposes etcd metrics as plain HTTP on :2381 with no target IPs set, so the headless service had zero endpoints and etcd metrics returned no data. Point kubeEtcd at all three control-plane nodes over HTTP:2381.