### PR TITLE
fix(rook-ceph): disable orphaned csi-metrics ServiceMonitor

### DIFF
--- a/kubernetes/apps/storage/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -25,7 +25,11 @@ spec:
       cephFSKernelMountOptions: ms_mode=prefer-crc
       enableLiveness: true
       serviceMonitor:
-        enabled: true
+        # ponytail: Rook v1.20.1 ships a csi-metrics ServiceMonitor but no backing
+        # csi-metrics service (CSI grpc-metrics removed upstream) -> 0 targets ->
+        # perpetual ScrapePoolHasNoTargets. Re-enable if Rook restores a scrapable
+        # CSI metrics service.
+        enabled: false
     monitoring:
       enabled: true
     resources:


### PR DESCRIPTION
Rook v1.20.1 creates a csi-metrics ServiceMonitor when csi.serviceMonitor is enabled, but no longer creates a backing csi-metrics service (CSI grpc-metrics removed upstream). The ServiceMonitor — converted to a VMServiceScrape — therefore discovers 0 targets, firing ScrapePoolHasNoTargets indefinitely. Disable it until Rook ships a scrapable CSI metrics service again.