### PR TITLE
fix(monitoring): silence RecordingRulesNoData for empty-by-design rules

### DIFF
--- a/kubernetes/apps/monitoring/victoriametrics/alerts/victoriametrics-vmalert-rules.yaml
+++ b/kubernetes/apps/monitoring/victoriametrics/alerts/victoriametrics-vmalert-rules.yaml
@@ -64,7 +64,7 @@ spec:
         "summary": |-
           Recording rule `{{ $labels.recording }}` ({{ $labels.group }}`) produces no data
       "expr": |-
-        sum(vmalert_recording_rules_last_evaluation_samples{group!="opentelemetry.5xx.rules"}) without(id) < 1
+        sum(vmalert_recording_rules_last_evaluation_samples{group!~"opentelemetry.5xx.rules|kube-prometheus-general.rules|kube-scheduler.rules",recording!="instance:node_load1_per_cpu:ratio"}) without(id) < 1
       "for": |-
         30m
       "labels":


### PR DESCRIPTION
Three sync-job-vendored kube-prometheus recording-rule groups trip RecordingRulesNoData with 0 samples, none of them an actual fault:

- kube-prometheus-general.rules (count:up0): empty whenever no target is down -- i.e. the healthy state. Cannot produce samples by design.
- kube-scheduler.rules: upstream rules hardcode job="kube-scheduler", but VM scrapes kube-scheduler under job="victoriametrics-kube-scheduler", so every rule in the group matches nothing. Metrics themselves are present.
- instance:node_load1_per_cpu:ratio: vector-match fails on extra ServiceMonitor labels vs the bare-label intermediate rule.

Extend the existing group-exclusion (opentelemetry.5xx.rules) to cover these, matching the precedent already in this alert.