### PR TITLE
fix(rook-ceph): disable unused CephFS CSI driver

### DIFF
--- a/kubernetes/apps/storage/rook-ceph/rook-ceph/csi-drivers/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/rook-ceph/rook-ceph/csi-drivers/app/helmrelease.yaml
@@ -20,7 +20,9 @@ spec:
   values:
     drivers:
       cephfs:
-        enabled: true
+        # No CephFS consumers (0 PVCs/PVs/attachments). Driver disabled to
+        # drop the broken nodeplugin DS + alert. Re-enable if CephFS is needed.
+        enabled: false
       nfs:
         enabled: false
       nvmeof:


### PR DESCRIPTION
Nothing consumes CephFS: 0 PVs on a cephfs driver, 0 PVCs on the ceph-filesystem StorageClass, 0 volumeattachments, and no repo manifest references it. The driver was misconfigured anyway -- the chart built the canonical cephfs.csi.ceph.com while the StorageClass uses the prefixed rook-ceph.cephfs.csi.ceph.com, whose pre-v1.20 leftover Driver/DS lost its ServiceAccount and now fails to schedule (KubeDaemonSetNotScheduled on edge002 after its reboot).

Rather than repair a driver with no consumers, disable it. Re-enable (with name: rook-ceph.cephfs.csi.ceph.com to match the StorageClass) if CephFS is ever needed.